### PR TITLE
feat: add basic network capture extension

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,59 @@
+const activeDebuggers = new Map();
+
+chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
+  if (message.command === 'start') {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) {
+      console.warn('No active tab to attach');
+      return;
+    }
+    const target = { tabId: tab.id };
+    try {
+      await chrome.debugger.attach(target, '1.3');
+      await chrome.debugger.sendCommand(target, 'Network.enable');
+      console.log('Attached to tab', tab.id);
+      activeDebuggers.set(tab.id, { target });
+    } catch (err) {
+      console.error('Failed to attach', err);
+    }
+  } else if (message.command === 'stop') {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) {
+      return;
+    }
+    const info = activeDebuggers.get(tab.id);
+    if (info) {
+      await chrome.debugger.detach(info.target);
+      activeDebuggers.delete(tab.id);
+      console.log('Detached from tab', tab.id);
+    }
+  }
+});
+
+chrome.debugger.onEvent.addListener(async (source, method, params) => {
+  if (!source.tabId || !activeDebuggers.has(source.tabId)) {
+    return;
+  }
+  switch (method) {
+    case 'Network.requestWillBeSent':
+    case 'Network.responseReceived':
+    case 'Network.webSocketCreated':
+    case 'Network.webSocketFrameSent':
+    case 'Network.webSocketFrameReceived':
+      console.log(method, params);
+      break;
+    case 'Network.loadingFinished':
+      console.log(method, params);
+      try {
+        const result = await chrome.debugger.sendCommand(source, 'Network.getResponseBody', { requestId: params.requestId });
+        const body = result.body || '';
+        const truncated = body.slice(0, 128 * 1024);
+        console.log('Response body for', params.requestId, truncated);
+      } catch (err) {
+        console.warn('No body for', params.requestId, err.message);
+      }
+      break;
+    default:
+      break;
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Browser Sniffer",
+  "version": "0.1.0",
+  "description": "Capture network activity via Chrome DevTools Protocol",
+  "permissions": ["debugger", "tabs", "activeTab"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Browser Sniffer</title>
+    <script src="popup.js"></script>
+  </head>
+  <body>
+    <button id="start">Start</button>
+    <button id="stop">Stop</button>
+  </body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('start').addEventListener('click', () => {
+    chrome.runtime.sendMessage({ command: 'start' });
+  });
+  document.getElementById('stop').addEventListener('click', () => {
+    chrome.runtime.sendMessage({ command: 'stop' });
+  });
+});


### PR DESCRIPTION
## Summary
- add MV3 manifest with debugger, tabs, and activeTab permissions
- implement background service worker to attach to current tab, enable network events, and log HTTP/WS activity and bodies
- add simple popup UI to start and stop capture

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b766ceab34832aac2c6b9aba25fcef