### PR TITLE
Prevent service worker registration failure on startup

### DIFF
--- a/background/main.js
+++ b/background/main.js
@@ -1,3 +1,10 @@
 import { loadSettings } from './settings.js';
-await loadSettings();
-await import('./runtime.js');
+
+(async () => {
+  try {
+    await loadSettings();
+  } catch (err) {
+    console.warn('Failed to load settings', err);
+  }
+  await import('./runtime.js');
+})();

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,5 +4,7 @@
 - Added configurable capture filters and thresholds (assets, analytics, WebSocket frames, body toggles) persisted in `chrome.storage`.
 
 - Fixed popup settings init to handle missing storage data and DOM elements gracefully.
+
+- Wrapped background service worker init to avoid registration failures when loading settings.
 =======
 


### PR DESCRIPTION
## Summary
- Wrap background service worker initialization in async IIFE with error handling
- Note fix in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'brain')*


------
https://chatgpt.com/codex/tasks/task_e_68b84de976f8832a9d9127bd979b8fe8