### PR TITLE
Fix service worker dynamic import error

### DIFF
--- a/background/main.js
+++ b/background/main.js
@@ -1,10 +1,8 @@
 import { loadSettings } from './settings.js';
+import './runtime.js';
 
-(async () => {
-  try {
-    await loadSettings();
-  } catch (err) {
-    console.warn('Failed to load settings', err);
-  }
-  await import('./runtime.js');
-})();
+try {
+  await loadSettings();
+} catch (err) {
+  console.warn('Failed to load settings', err);
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,13 +3,7 @@
 ## Unreleased
 - Added configurable capture filters and thresholds (assets, analytics, WebSocket frames, body toggles) persisted in `chrome.storage`.
 - Fixed popup settings init to handle missing storage data and DOM elements gracefully.
-
 - Wrapped background service worker init to avoid registration failures when loading settings.
 - Removed duplicate legacy settings logic from popup script causing runtime errors.
 - Cleaned up stale conflict markers in documentation.
-
-
-- Wrapped background service worker init to avoid registration failures when loading settings.
-=======
-
-
+- Replaced disallowed dynamic import in service worker with static import to restore background functionality.


### PR DESCRIPTION
## Summary
- replace dynamic import in background service worker with static import
- document service worker import change in changelog

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'brain')*

------
https://chatgpt.com/codex/tasks/task_e_68b85de704b4832aa6103a079300bc02