### PR TITLE
Avoid top-level await in service worker

### DIFF
--- a/background/main.js
+++ b/background/main.js
@@ -1,8 +1,6 @@
 import { loadSettings } from './settings.js';
 import './runtime.js';
 
-try {
-  await loadSettings();
-} catch (err) {
+loadSettings().catch(err => {
   console.warn('Failed to load settings', err);
-}
+});

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,3 +7,4 @@
 - Removed duplicate legacy settings logic from popup script causing runtime errors.
 - Cleaned up stale conflict markers in documentation.
 - Replaced disallowed dynamic import in service worker with static import to restore background functionality.
+- Removed top-level await in service worker initialization to ensure reliable registration.


### PR DESCRIPTION
## Summary
- remove top-level await in `background/main.js` so the service worker registers cleanly
- document the change in the changelog

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'brain.main')*

------
https://chatgpt.com/codex/tasks/task_e_68b860d377c0832aa70a6823733faef8