### PR TITLE
Fix popup buttons unresponsive during settings load

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,3 +9,4 @@
 - Replaced disallowed dynamic import in service worker with static import to restore background functionality.
 - Removed top-level await in service worker initialization to ensure reliable registration.
 - Added explicit messaging handshake between popup and background to restore functional control buttons.
+- Bound popup control button handlers before async settings load to avoid unresponsive UI.

--- a/popup.js
+++ b/popup.js
@@ -8,8 +8,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   };
 
-  let settings = {};
+  // Bind button handlers immediately so the popup stays responsive even if
+  // settings loading stalls.
+  $('#start')?.addEventListener('click', () => { send('start'); });
+  $('#stop')?.addEventListener('click', () => { send('stop'); });
+  $('#export')?.addEventListener('click', () => { send('export'); });
+  $('#purge')?.addEventListener('click', () => { send('purge'); });
 
+  // Load settings asynchronously after handlers are in place
+  let settings = {};
   try {
     ({ settings } = await chrome.storage.sync.get(['settings']));
   } catch (err) {
@@ -54,9 +61,4 @@ document.addEventListener('DOMContentLoaded', async () => {
       console.warn('settings save failed', err);
     }
   });
-
-  $('#start')?.addEventListener('click', () => { send('start'); });
-  $('#stop')?.addEventListener('click', () => { send('stop'); });
-  $('#export')?.addEventListener('click', () => { send('export'); });
-  $('#purge')?.addEventListener('click', () => { send('purge'); });
 });


### PR DESCRIPTION
## Summary
- Bind popup control button handlers immediately so settings load delays don't block Start/Stop/Export/Purge
- Document button handler fix in changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'brain')*


------
https://chatgpt.com/codex/tasks/task_e_68b86445bc70832a8468356972b7661b